### PR TITLE
Enable tests without graphics

### DIFF
--- a/src/Modia3D.jl
+++ b/src/Modia3D.jl
@@ -60,7 +60,7 @@ Currently, only DynamicAnalysis is supported and used.
 
 
 # Used renderer (actual value is defined with __init__() below)
-const renderer = Vector{AbstractRenderer}(undef,1)
+const renderer = Vector{AbstractRenderer}(undef,2)
 
 
 
@@ -136,6 +136,18 @@ function __init__()
     else
         renderer[1] = DLR_Visualization.CommunityEdition(info)
 end; end
+
+function disableRenderer()
+    renderer[2] = renderer[1]
+    renderer[1] = NoRenderer.DummyRenderer(0)
+    return nothing
+end
+function reenableRenderer()
+    if !isnothing(renderer[2])
+        renderer[1] = renderer[2]
+    end
+    return nothing
+end
 
 
 export Object3D

--- a/test/includeTests.jl
+++ b/test/includeTests.jl
@@ -1,0 +1,59 @@
+import Test
+
+Test.@testset "Basic" begin
+    include(joinpath("Basic", "AllShapes.jl"))
+    include(joinpath("Basic", "PendulumWithBar1.jl"))
+    include(joinpath("Basic", "PendulumWithBar2.jl"))
+    include(joinpath("Basic", "PendulumWithDamper.jl"))
+    include(joinpath("Basic", "PendulumWithFix.jl"))
+    include(joinpath("Basic", "PendulumWithParameterizedDamper.jl"))
+    include(joinpath("Basic", "PendulumWithSpring.jl"))
+    include(joinpath("Basic", "DoublePendulumWithDampers.jl"))
+    include(joinpath("Basic", "Mobile.jl"))
+    include(joinpath("Basic", "ShaftFreeMotion.jl"))
+    Test.@test_throws LoadError include(joinpath("Basic", "Object3DWithoutParentError.jl"))
+end
+
+Test.@testset "Robot" begin
+    include(joinpath("Robot", "ServoWithRamp.jl"))
+    include(joinpath("Robot", "ServoWithRampAndPrismatic.jl"))
+    include(joinpath("Robot", "ServoWithRampAndRevolute.jl"))
+    include(joinpath("Robot", "ServoWithPathAndRevolute.jl"))
+    include(joinpath("Robot", "YouBotWithSphere.jl"))
+    Test.@test_skip include(joinpath("Robot", "YouBotPingPong.jl")) # too long computation time
+    include(joinpath("Robot", "YouBotGripping.jl"))
+    Test.@test_skip include(joinpath("Robot", "YouBotsGripping.jl")) # too long computation time
+end
+
+Test.@testset "Collision" begin
+    include(joinpath("Collision", "BouncingSphere.jl"))
+    include(joinpath("Collision", "BouncingSphereFreeMotion.jl"))
+    include(joinpath("Collision", "BouncingEllipsoid.jl"))
+    include(joinpath("Collision", "BouncingCones.jl"))
+    include(joinpath("Collision", "BouncingCapsules.jl"))
+    include(joinpath("Collision", "BouncingBeams.jl"))
+    include(joinpath("Collision", "TwoCollidingBalls.jl"))
+    include(joinpath("Collision", "TwoCollidingBoxes.jl"))
+    include(joinpath("Collision", "CollidingCylinders.jl"))
+    include(joinpath("Collision", "CollidingSphereWithBunnies.jl"))
+    include(joinpath("Collision", "NewtonsCradle.jl"))
+    include(joinpath("Collision", "Billard4Balls.jl"))
+    Test.@test_skip include(joinpath("Collision", "Billard16Balls.jl"))  # too long computation time
+end
+
+Test.@testset "Tutorial" begin
+    include(joinpath("Tutorial", "Pendulum1.jl"))
+    include(joinpath("Tutorial", "Pendulum2.jl"))
+    include(joinpath("Tutorial", "Pendulum3.jl"))
+    include(joinpath("Tutorial", "BouncingSphere.jl"))
+end
+
+Test.@testset "old" begin
+    include(joinpath("old", "Move_Pendulum.jl"))
+    Test.@test_skip include(joinpath("old", "Plot_cor.jl"))  # direct PyPlot calls
+    Test.@test_skip include(joinpath("old", "Plot_SlidingFriction.jl"))  # direct PyPlot calls
+    include(joinpath("old", "test_Shapes.jl"))
+    include(joinpath("old", "Test_PathPlanning.jl"))
+    include(joinpath("old", "test_Solids.jl"))
+    include(joinpath("old", "Visualize_Beam.jl"))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,69 +1,14 @@
 module Runtests
 
-import Test
 using  ModiaLang
+import Modia3D
+import Test
 
-@time Test.@testset verbose=true "Modia3D" begin
+@time Test.@testset verbose=true "Modia3D (with SilentNoPlot)" begin
     usePlotPackage("SilentNoPlot")
-
-    Test.@testset "Basic" begin
-        include(joinpath("Basic", "AllShapes.jl"))
-        include(joinpath("Basic", "PendulumWithBar1.jl"))
-        include(joinpath("Basic", "PendulumWithBar2.jl"))
-        include(joinpath("Basic", "PendulumWithDamper.jl"))
-        include(joinpath("Basic", "PendulumWithFix.jl"))
-        include(joinpath("Basic", "PendulumWithParameterizedDamper.jl"))
-        include(joinpath("Basic", "PendulumWithSpring.jl"))
-        include(joinpath("Basic", "DoublePendulumWithDampers.jl"))
-        include(joinpath("Basic", "Mobile.jl"))
-        include(joinpath("Basic", "ShaftFreeMotion.jl"))
-        Test.@test_throws LoadError include(joinpath("Basic", "Object3DWithoutParentError.jl"))
-    end
-
-    Test.@testset "Robot" begin
-        include(joinpath("Robot", "ServoWithRamp.jl"))
-        include(joinpath("Robot", "ServoWithRampAndPrismatic.jl"))
-        include(joinpath("Robot", "ServoWithRampAndRevolute.jl"))
-        include(joinpath("Robot", "ServoWithPathAndRevolute.jl"))
-        include(joinpath("Robot", "YouBotWithSphere.jl"))
-        Test.@test_skip include(joinpath("Robot", "YouBotPingPong.jl")) # too long computation time
-        include(joinpath("Robot", "YouBotGripping.jl"))
-        Test.@test_skip include(joinpath("Robot", "YouBotsGripping.jl")) # too long computation time
-    end
-
-    Test.@testset "Collision" begin
-        include(joinpath("Collision", "BouncingSphere.jl"))
-        include(joinpath("Collision", "BouncingSphereFreeMotion.jl"))
-        include(joinpath("Collision", "BouncingEllipsoid.jl"))
-        include(joinpath("Collision", "BouncingCones.jl"))
-        include(joinpath("Collision", "BouncingCapsules.jl"))
-        include(joinpath("Collision", "BouncingBeams.jl"))
-        include(joinpath("Collision", "TwoCollidingBalls.jl"))
-        include(joinpath("Collision", "TwoCollidingBoxes.jl"))
-        include(joinpath("Collision", "CollidingCylinders.jl"))
-        include(joinpath("Collision", "CollidingSphereWithBunnies.jl"))
-        include(joinpath("Collision", "NewtonsCradle.jl"))
-        include(joinpath("Collision", "Billard4Balls.jl"))
-        Test.@test_skip include(joinpath("Collision", "Billard16Balls.jl"))  # too long computation time
-    end
-
-    Test.@testset "Tutorial" begin
-        include(joinpath("Tutorial", "Pendulum1.jl"))
-        include(joinpath("Tutorial", "Pendulum2.jl"))
-        include(joinpath("Tutorial", "Pendulum3.jl"))
-        include(joinpath("Tutorial", "BouncingSphere.jl"))
-    end
-
-    Test.@testset "old" begin
-        include(joinpath("old", "Move_Pendulum.jl"))
-        include(joinpath("old", "Plot_cor.jl"))
-        include(joinpath("old", "Plot_SlidingFriction.jl"))
-        include(joinpath("old", "test_Shapes.jl"))
-        include(joinpath("old", "Test_PathPlanning.jl"))
-        include(joinpath("old", "test_Solids.jl"))
-        include(joinpath("old", "Visualize_Beam.jl"))
-    end
-
+    Modia3D.disableRenderer()
+    include("includeTests.jl")
+    Modia3D.reenableRenderer()
     usePreviousPlotPackage()
 end
 

--- a/test/runtestsWithGraphics.jl
+++ b/test/runtestsWithGraphics.jl
@@ -1,0 +1,12 @@
+module RuntestsWithGraphics
+
+using  ModiaLang
+import Test
+
+const title = "Modia3D (with " * currentPlotPackage() * ")"
+
+@time Test.@testset verbose=true "$title" begin
+    include("includeTests.jl")
+end
+
+end


### PR DESCRIPTION
- Add provisorial functions to dis-/re-enable renderer.
- Disable renderer in runtests.jl.
- Add runtestsWithGraphics.jl with renderer and plots enabled.