### PR TITLE
Split setting of joint variables (improves efficiency)

### DIFF
--- a/src/Composition/_module.jl
+++ b/src/Composition/_module.jl
@@ -32,8 +32,7 @@ export Revolute, setAngle!, connect
 export Prismatic, setDistance!
 export FreeMotion
 
-# export getModelResidues!, model_f1!, model_f2!
-export multibodyResiduals
+export multibodyResiduals!, setModiaJointVariables!
 
 export distanceAndAngles, distance, planarRotationAngle
 export measFrameRotation, measFramePosition, measFrameDistance
@@ -67,7 +66,7 @@ export fullName, instanceName
 
 export InteractionBehavior, Gripper, Movable, Lockable, NoInteraction
 
-export rot123fromR
+export rot123fromR, rot132fromR, Rfromrot123, Rfromrot132
 
 export supportPoint, boundingBox!
 

--- a/src/Composition/dynamics.jl
+++ b/src/Composition/dynamics.jl
@@ -343,9 +343,9 @@ function multibodyResiduals3!(sim, scene, world, time, storeResults, isTerminal,
                 if abs(sim.options.startTime + scene.outputCounter*sim.options.interval - time) < 1.0e-6*(abs(time) + 1.0)
                     # Visualize at a communication point
                     scene.outputCounter += 1
-                    if sim.options.log
-                        println("time = $time")
-                    end
+                    #if sim.options.log
+                    #    println("time = $time")
+                    #end
                     # Compute positions of frames that are only used for visualization
                     TimerOutputs.@timeit sim.timer "Modia3D_3 visualize!" begin
                         if scene.options.useOptimizedStructure

--- a/src/Composition/dynamics.jl
+++ b/src/Composition/dynamics.jl
@@ -101,31 +101,26 @@ struct MultibodyData{FloatType}
 end
 
 
-function multibodyResiduals(id::Int, _leq_mode, simulationModel::ModiaLang.SimulationModel{FloatType}, time, qdd, args...)::Vector{FloatType} where {FloatType}
-     TimerOutputs.@timeit simulationModel.timer "Modia3D" begin
-        separateObjects = simulationModel.separateObjects  # is emptied for every new simulate! call
-        parameters      = simulationModel.evaluatedParameters
+"""
+    jointVariablesHaveValues = setModiaJointVariables!(_id, _leq_mode, instantiatedModel, time, args...)
+
+Set generalized variables (q, qd, f) defined in the Modia model for all joints.
+"""
+function setModiaJointVariables!(id::Int, _leq_mode, instantiatedModel::ModiaLang.SimulationModel{FloatType}, time, args...)::Bool where {FloatType}
+     TimerOutputs.@timeit instantiatedModel.timer "Modia3D_0" begin
+        separateObjects = instantiatedModel.separateObjects  # is emptied for every new simulate! call
         if haskey(separateObjects, id)
-            first = false
             mbs::MultibodyData{FloatType} = separateObjects[id]
-            @assert(length(qdd) == mbs.nqdd)
-            world           = mbs.world
             scene           = mbs.scene
             jointObjects    = mbs.jointObjects
             jointStartIndex = mbs.jointStartIndex
             jointNdof       = mbs.jointNdof
-            residuals       = mbs.residuals
-            cache_h         = mbs.cache_h
-            zStartIndex     = mbs.zStartIndex
-            nz              = mbs.nz
         else
-            first = true
-
             # Search in parameters and retrieve the name of the object with the required id
             # Instantiate the Modia3D system
             #mbsPar = getIdParameter(parameters, id)
-            #mbsObj = instantiateDependentObjects(simulationModel.modelModule, mbsPar)
-            (world, jointObjects) = checkMultibodySystemAndGetWorldAndJoints(simulationModel, id)
+            #mbsObj = instantiateDependentObjects(instantiatedModel.modelModule, mbsPar)
+            (world, jointObjects) = checkMultibodySystemAndGetWorldAndJoints(instantiatedModel, id)
 
             # Construct startIndex vector and number of degrees of freedom per joint
             nJoints         = length(jointObjects)
@@ -138,10 +133,6 @@ function multibodyResiduals(id::Int, _leq_mode, simulationModel::ModiaLang.Simul
                 j += jointNdof[i]
             end
             nqdd = j-1
-            if length(qdd) != nqdd
-                error("Bug in Modia3D/src/Composition/dynamics.jl or in the generated code:\n",
-                    "   length(qdd) = ", length(qdd), " is not identical to nqdd = ", nqdd)
-            end
 
             # Construct MultibodyData
             scene = initAnalysis2!(world)
@@ -149,35 +140,62 @@ function multibodyResiduals(id::Int, _leq_mode, simulationModel::ModiaLang.Simul
             cache_h   = zeros(FloatType,nqdd)
             if scene.options.enableContactDetection
                 nz = 2
-                zStartIndex = ModiaLang.addZeroCrossings(simulationModel, nz)
+                zStartIndex = ModiaLang.addZeroCrossings(instantiatedModel, nz)
             else
                 nz = 0
                 zStartIndex = 0
             end
-            mbs = MultibodyData{FloatType}(length(qdd), world, scene, jointObjects, jointStartIndex,
-                                        jointNdof, zStartIndex, nz, residuals, cache_h)
+            mbs = MultibodyData{FloatType}(nqdd, world, scene, jointObjects, jointStartIndex,
+                                           jointNdof, zStartIndex, nz, residuals, cache_h)
             separateObjects[id] = mbs
-
-            if simulationModel.options.log && scene.visualize
-                println("          Modia3D: Number of visual shapes = ", length(scene.allVisuElements))
-            end
 
             # Print
             if false
                 printScene(scene)
             end
+
+            if scene.visualize
+                TimerOutputs.@timeit instantiatedModel.timer "Modia3D_0 initializeVisualization" Modia3D.Composition.initializeVisualization(Modia3D.renderer[1], scene.allVisuElements)
+                if instantiatedModel.options.log
+                    println("        Modia3D: Number of visual shapes = ", length(scene.allVisuElements))
+                end
+            end
         end
 
-        # Copy generalized position, velocity, acceleration, force values in to the joints
+        # Copy generalized position, velocity, and force values in to the joints
         @assert(length(args) == length(jointObjects))
-        setJointVariables!(scene, jointObjects, args, qdd, jointStartIndex, jointNdof)::Nothing
+        setJointVariables_q_qd_f!(scene, jointObjects, jointStartIndex, jointNdof, args)
+    end
+    return true
+end
+
+
+
+function multibodyResiduals!(id::Int, _leq_mode, instantiatedModel::ModiaLang.SimulationModel{FloatType}, time, jointVariablesHaveValues::Bool, qdd)::Vector{FloatType} where {FloatType}
+     TimerOutputs.@timeit instantiatedModel.timer "Modia3D" begin
+        separateObjects = instantiatedModel.separateObjects  # is emptied for every new simulate! call
+        if !haskey(separateObjects, id)
+            error("Bug in Modia3D/src/composition/dynamics.jl: separateObjects[$id] is not defined.")
+        end
+        mbs::MultibodyData{FloatType} = separateObjects[id]
+        @assert(length(qdd) == mbs.nqdd)
+        world           = mbs.world
+        scene           = mbs.scene
+        jointObjects    = mbs.jointObjects
+        jointStartIndex = mbs.jointStartIndex
+        jointNdof       = mbs.jointNdof
+        residuals       = mbs.residuals
+        cache_h         = mbs.cache_h
+
+        # Set generalized joint accelerations
+        setJointVariables_qdd!(scene, jointObjects, jointStartIndex, jointNdof, qdd)
 
         # Compute residuals
         leq_mode = isnothing(_leq_mode) ? -1 : _leq_mode.mode
 
         # Method with improved efficiency
-        multibodyResiduals3!(simulationModel, scene, world, time, simulationModel.storeResult, first,
-                            ModiaLang.isTerminal(simulationModel) && leq_mode == -1, leq_mode)
+        multibodyResiduals3!(instantiatedModel, scene, world, time, instantiatedModel.storeResult,
+                             ModiaLang.isTerminal(instantiatedModel) && leq_mode == -1, leq_mode)
 
         # Copy the joint residuals in to the residuals vector
         if leq_mode == 0
@@ -233,18 +251,10 @@ For Modia3D:
                    return res := res + cache_h
 =#
 
-function multibodyResiduals3!(sim, scene, world, time, storeResults, isFirstInitial, isTerminal, leq_mode)
+function multibodyResiduals3!(sim, scene, world, time, storeResults, isTerminal, leq_mode)
     tree            = scene.treeForComputation
     visualize       = scene.visualize   # && sim.model.visualiz
     exportAnimation = scene.exportAnimation
-
-    # Handle initialization and termination of model
-    # if Modia.isFirstInitialOfAllSegments(sim)
-    if isFirstInitial
-        if visualize
-            TimerOutputs.@timeit sim.timer "Modia3D_0 initializeVisualization" Modia3D.Composition.initializeVisualization(Modia3D.renderer[1], scene.allVisuElements)
-        end
-    end
 
     if isTerminal  #if Modia.isTerminalOfAllSegments(sim)
         TimerOutputs.@timeit sim.timer "Modia3D_4 isTerminal" begin

--- a/src/Composition/joints/object3DMotion.jl
+++ b/src/Composition/joints/object3DMotion.jl
@@ -17,10 +17,11 @@ end
     joint = FreeMotion(; obj1, obj2, path="", r, rot, v, w)
 
 Return a `joint` that describes the free movement of `obj2::`[`Object3D`](@ref)
-with respect to `obj1::`[`Object3D`](@ref). The initial position is `r` and the
-initial orientation is `rot` in [Cardan (Tait–Bryan) angles](https://en.wikipedia.org/wiki/Euler_angles#Chained_rotations_equivalence)
-(rotation sequence x-y-z). `v` and `w` are the initial cartesian translational
-and rotational velocity vectors.
+with respect to `obj1::`[`Object3D`](@ref). The initial position is `r`
+(resolved in `obj1`) and the initial orientation is `rot` in [Cardan (Tait–Bryan) angles](https://en.wikipedia.org/wiki/Euler_angles#Chained_rotations_equivalence)
+(rotation sequence x-y-z from `obj1` to `obj2`). `v` (resolved in `obj1`) and `w`
+(resolved in `obj2`) are the initial cartesian translational and rotational
+velocity vectors.
 """
 mutable struct FreeMotion <: Modia3D.AbstractJoint
     path::String

--- a/src/ModiaInterface/_module.jl
+++ b/src/ModiaInterface/_module.jl
@@ -12,7 +12,7 @@ export UniformGravityField
 export RefPath, ptpJointSpace, scheduleReferenceMotion
 export calculateRobotMovement
 export getRefPathPosition, getRefPathInitPosition, getVariables
-export multibodyResiduals
+export multibodyResiduals!, setModiaJointVariables!
 export Fix
 export Revolute, RevoluteWithFlange
 export Prismatic, PrismaticWithFlange

--- a/src/ModiaInterface/buildModia3D.jl
+++ b/src/ModiaInterface/buildModia3D.jl
@@ -43,7 +43,8 @@ function buildModia3D(model)    #(model; path="")
 
     mbsCode = Model(_id = rand(Int),
                     _qdd = Var(start = zeros(ndofTotal)),
-                    mbs_equations = :[0 = multibodyResiduals(_id, _leq_mode, instantiatedModel, time, _qdd, $(args...))
+                    mbs_equations = :[jointVariablesHaveValues = setModiaJointVariables!(_id, _leq_mode, instantiatedModel, time, $(args...))
+                                      0 = multibodyResiduals!(_id, _leq_mode, instantiatedModel, time, jointVariablesHaveValues, _qdd)
                                       $(code...)])
 
                     #mbs_equations = :[zeros($ndofTotal) = multibodyResiduals(_id, _leq_mode, instantiatedModel, time, _qdd, $(args...))

--- a/src/ModiaInterface/model3D.jl
+++ b/src/ModiaInterface/model3D.jl
@@ -38,7 +38,8 @@ getRefPathInitPosition(args...) = Modia3D.getRefPathInitPosition(args...)
 
 getVariables(args...) = (args...,)
 
-multibodyResiduals(args...) = Modia3D.multibodyResiduals(args...)
+multibodyResiduals!(args...)     = Modia3D.multibodyResiduals!(args...)
+setModiaJointVariables!(args...) = Modia3D.setModiaJointVariables!(args...)
 
 Revolute(; obj1, obj2, axis=3, phi=Var(init=0.0), w=Var(init=0.0), canCollide=true) = Model(; _constructor = Par(value = :(Modia3D.Revolute), _path = true, ndof = 1),
     obj1 = Par(value = obj1),


### PR DESCRIPTION
runtests.jl is successful (but requires Modia3D branch otter_splitSettingOfJointVariables)