### PR TITLE
Animation export: Fix initial orientation

### DIFF
--- a/src/Composition/joints/FreeMotion.jl
+++ b/src/Composition/joints/FreeMotion.jl
@@ -17,14 +17,14 @@ In case of singular state (angle2 +-90 deg, x and z axes parallel) `rot3_guess` 
 """
 function rot123fromR(R::Frames.RotationMatrix; rot3_guess=0.0)
 
-    sbe = R[3,1]
+    sbe = clamp(R[3,1], -1.0, 1.0)
     cbe2 = 1.0 - sbe*sbe
     if (cbe2 > 1e-12)
         al = atan(-R[3,2], R[3,3])
         be = atan(sbe/sqrt(cbe2))
         ga = atan(-R[2,1], R[1,1])
     else
-        # be is 90 deg -> singular, only al+ga is defined -> set ga to zero
+        # be is 90 deg -> singular, only al+ga is defined -> set ga to rot3_guess
         al = atan(R[2,3], R[2,2]) - sign(sbe)*rot3_guess  # ???
         be = sign(sbe)*0.5*pi
         ga = rot3_guess
@@ -41,7 +41,7 @@ In case of singular state (angle2 +-90 deg, x and y axes parallel) `rot3_guess` 
 """
 function rot132fromR(R::Frames.RotationMatrix; rot3_guess=0.0)
 
-    sga = - R[2,1]
+    sga = clamp(-R[2,1], -1.0, 1.0)
     cga2 = 1.0 - sga*sga
     if (cga2 > 1e-12)
         al = atan(R[2,3], R[2,2])

--- a/src/Composition/scene.jl
+++ b/src/Composition/scene.jl
@@ -252,8 +252,8 @@ function cameraPosition(distance, longitude, latitude, cameraUpDir, sceneUpDir)
     else
         # camera upwards := +y direction
     end
-    r_Camera = R_view' * r_Camera
-    R_Camera = R_Camera * R_view
+    r_Camera = SVector{3,Float64}(R_view' * r_Camera)
+    R_Camera = SMatrix{3,3,Float64}(R_Camera * R_view)
     return (r_Camera, R_Camera)
 end
 
@@ -396,12 +396,12 @@ struct SceneOptions <: Modia3D.AbstractSceneOptions
 end
 
 struct animationData
-    position::SVector{3,Float32}    # abs. Object3D position
-    quaternion::SVector{4,Float32}  # abs. Object3D quaternion
+    position::SVector{3,Float64}    # abs. Object3D position
+    quaternion::SVector{4,Float64}  # abs. Object3D quaternion
 end
 
 struct animationStep
-    time::Float32                      # simulation time
+    time::Float64                      # simulation time
     objectData::Vector{animationData}  # animation data of Object3Ds
 end
 


### PR DESCRIPTION
- Use consistently Float64 for animation data to avoid wrong initial orientation caused by round-off errors (e.g. in test models BouncingCapsules.jl, BouncingCones.jl and NewtonsCradle.jl).
- Simplify total quaternion calculation for animation.