### PR TITLE
Improve corner cases and error messages

### DIFF
--- a/src/Composition/dynamics.jl
+++ b/src/Composition/dynamics.jl
@@ -12,10 +12,10 @@ function getJointsAndForceElementsAndObject3DsWithoutParents!(evaluatedParameter
                 if typeof(value.feature) <: Scene
                     push!(object3DWithoutParents, value)
                 else
-                    error("\n", value.path, " is an Object3D that has no parent, but no feature=Scene(..)!\n")
+                    error("\n", value.path, " is an Object3D that has no parent, but no feature=Scene(..)!\nThis means no Scene is defined (exactly one Object3D must have feature=Scene(..))!")
                 end
             elseif typeof(value.feature) <: Scene
-                error("\n", value.path, " is an Object3D that has feature=Scene(..) and has a parent (= ", value.parent.path, ")!\n")
+                error("\n", value.path, " is an Object3D that has feature=Scene(..) and has a parent (= ", value.parent.path, ")!\nThe Object3D with feature=Scene(..) is not allowed to have a parent!")
             end
 
         elseif typeof(value) <: Modia3D.Composition.Revolute 

--- a/src/Composition/joints/Fix.jl
+++ b/src/Composition/joints/Fix.jl
@@ -34,11 +34,7 @@ struct Fix{F <: Modia3D.VarFloatType}
                 translation::AbstractVector = Modia3D.ZeroVector3D(F),
                 rotation::AbstractVector    = Modia3D.ZeroVector3D(F)) where F <: Modia3D.VarFloatType
 
-        (parent, child, cutJoint) = attach(obj1, obj2)
-        if cutJoint
-        error("\nError from Fix joint connecting ", Modia3D.fullName(obj1), " with ", Modia3D.fullName(obj2), ":",
-            "\nThis joint is a cut-joint which is not allowed.")
-        end
+        (parent, child, cutJoint) = attach(obj1, obj2, name = "Fix joint")  # an error is triggered if cutJoint=true
 
         r_rel = Modia3D.convertAndStripUnit(SVector{3,F}, u"m", translation)
         rot   = Modia3D.convertAndStripUnit(SVector{3,F}, u"rad", rotation)

--- a/src/Composition/joints/Prismatic.jl
+++ b/src/Composition/joints/Prismatic.jl
@@ -16,7 +16,7 @@ get_eAxis(::Type{F}, axis::Int) where F <: Modia3D.VarFloatType = axis==  1 ? SV
                        error("Modia3D.Composition.Prismatic: axis = ", axis, " but must be 1, 2, 3, -1, -2, or -3.")
 
 """
-    joint = Prismatic(; obj1, obj2, path="", axis=1, s=0, v=0, canCollide=true)
+    joint = Prismatic(; obj1, obj2, axis=1, s=0, v=0, canCollide=true)
 
 Return a `joint` that translates `obj2::`[`Object3D`](@ref) with respect to
 `obj1::`[`Object3D`](@ref) along coordinate axis `axis` (`axis = 1,2,3,-1,-2,-3`)

--- a/src/Composition/joints/Prismatic.jl
+++ b/src/Composition/joints/Prismatic.jl
@@ -52,11 +52,7 @@ mutable struct Prismatic{F <: Modia3D.VarFloatType} <: Modia3D.AbstractJoint
                          v::Real   = F(0.0),
                          canCollide::Bool = true) where F <: Modia3D.VarFloatType
 
-        (parent,obj,cutJoint) = attach(obj1, obj2)
-        if cutJoint
-            error("\nError from Prismatic joint connecting ", Modia3D.fullName(obj1), " with ", Modia3D.fullName(obj2), ":\n",
-                "    This joint is a cut-joint which is currently not supported.!")
-        end
+        (parent,obj,cutJoint) = attach(obj1, obj2, name = "Prismatic joint")  # an error is triggered if cutJoint=true
 
         if !(1 <= abs(axis) <= 3)
             error("\nError from Prismatic joint connecting ", Modia3D.fullName(obj1), " with ", Modia3D.fullName(obj2), ":\n",

--- a/src/Composition/joints/Revolute.jl
+++ b/src/Composition/joints/Revolute.jl
@@ -8,7 +8,7 @@ import Modia3D.Frames
 
 
 """
-    joint = Revolute(;obj1, obj2, path="", axis=3, phi=0, w=0, canCollide=false)
+    joint = Revolute(;obj1, obj2, axis=3, phi=0, w=0, canCollide=false)
 
 Return a Revolute `joint` that rotates `obj1::`[`Object3D`](@ref) into
 `obj2::`[`Object3D`](@ref) along the axis `axis` of `obj1` (`axis = 1,2,3,-1,-2,-3`).

--- a/src/Composition/joints/Revolute.jl
+++ b/src/Composition/joints/Revolute.jl
@@ -43,11 +43,7 @@ mutable struct Revolute{F <: Modia3D.VarFloatType} <: Modia3D.AbstractJoint
                         w::Real   = F(0.0),
                         canCollide::Bool = false) where F <: Modia3D.VarFloatType
 
-        (parent,obj,cutJoint) = attach(obj1, obj2)
-        if cutJoint
-            error("\nError from Revolute joint connecting ", Modia3D.fullName(obj1), " with ", Modia3D.fullName(obj2), ":\n",
-                "    This joint is a cut-joint which is currently not supported.!")
-        end
+        (parent,obj,cutJoint) = attach(obj1, obj2, name = "Revolute joint")  # an error is triggered if cutJoint=true
 
         if !(1 <= abs(axis) <= 3)
             error("\nError from Revolute joint connecting ", Modia3D.fullName(obj1), " with ", Modia3D.fullName(obj2), ":\n",

--- a/src/Composition/joints/joints.jl
+++ b/src/Composition/joints/joints.jl
@@ -120,6 +120,8 @@ function attachAndReverseParents(newParent::Object3D{F}, obj::Object3D{F})::Noth
 end
 
 
+getParents(obj,rootPath) = "\"" * Modia3D.fullName(obj) * "\" has " * (length(rootPath) == 0 ? "no parents" : "parents: $rootPath")
+
 """
     (obj1, obj2, cutJoint) = attach(frame_a, frame_b)
 
@@ -128,7 +130,7 @@ and cutJoint = false is returned.
 
 If they have the same root, the tree is not modified and cutJoint=true is returned.
 """
-function attach(obj1::Object3D, obj2::Object3D)
+function attach(obj1::Object3D, obj2::Object3D; name = "")
    root1 = rootObject3D(obj1)
    root2 = rootObject3D(obj2)
    #println("attach: obj1 = ", Modia3D.fullName(obj1), ", root = ", Modia3D.fullName(root1))
@@ -137,6 +139,16 @@ function attach(obj1::Object3D, obj2::Object3D)
    if root1 ≡ root2
       # Compute absolute positions
       # updatePosition!(root1)
+
+      if name != ""
+        # Collect all objects that form a loop
+        rootPath1 = rootObject3DPath(obj1)
+        rootPath2 = rootObject3DPath(obj2)
+        error("\nError from $name connecting \"", Modia3D.fullName(obj1), "\" with \"", Modia3D.fullName(obj2), "\":\n",
+                "    ", getParents(obj1,rootPath1), "\n",
+                "    ", getParents(obj2,rootPath2), "\n",
+                "    Therefore, a closed kinematic loop is defined, which is currently not supported.")
+      end     
       return (obj1,obj2,true)
    end
 

--- a/src/Composition/joints/object3DMotion.jl
+++ b/src/Composition/joints/object3DMotion.jl
@@ -14,7 +14,7 @@ end
 
 
 """
-    joint = FreeMotion(; obj1, obj2, path="", r, rot, v, w)
+    joint = FreeMotion(; obj1, obj2, r, rot, v, w)
 
 Return a `joint` that describes the free movement of `obj2::`[`Object3D`](@ref)
 with respect to `obj1::`[`Object3D`](@ref). The initial position is `r`

--- a/src/Composition/massPropertiesComputation.jl
+++ b/src/Composition/massPropertiesComputation.jl
@@ -104,7 +104,7 @@ function addOrSubtractMassPropertiesOfChildToRoot!(obj_root::Object3D{F}, obj_ch
         m = m_root + m_child
 
         # common center of mass (parent + child)
-        @assert(m > 0.0)
+        @assert(m >= 0.0)
         rCM = (m_root * rCM_root + m_child * rCM_child_new)/m
 
         # I: substract new common mass multiplied with skew matrices of

--- a/src/Composition/object3D.jl
+++ b/src/Composition/object3D.jl
@@ -551,6 +551,18 @@ function rootObject3D(obj::Object3D{F}) where F <: Modia3D.VarFloatType
 end
 
 
+"""    path = rootObject3DPath(obj) - returns a vector of Object3D names of all objects from obj to root"""
+function rootObject3DPath(obj::Object3D{F}) where F <: Modia3D.VarFloatType
+    path = String[]
+    obj1 = obj
+    while hasParent(obj1)
+        obj1 = obj1.parent
+        push!(path, obj1.path)
+    end
+    return path
+end
+
+
 """    removeChild!(obj, child) - Remove child from obj.children"""
 function removeChild!(obj::Object3D{F}, child::Object3D{F})::Nothing where F <: Modia3D.VarFloatType
     children = obj.children

--- a/src/ModiaInterface/buildModia3D.jl
+++ b/src/ModiaInterface/buildModia3D.jl
@@ -97,6 +97,8 @@ function buildModia3D!(model::AbstractDict, FloatType::Type, TimeType::Type,
     jointStatesFreeMotion_isrot123 = Expr[]
     freeMotionIndices              = OrderedCollections.OrderedDict{String,Int}()
 
+    println("modelPath = $modelPath")
+    
     modelPathAsString = isnothing(modelPath) ? "" : string(modelPath)
     
     i=1
@@ -243,6 +245,9 @@ function buildModia3D!(model::AbstractDict, FloatType::Type, TimeType::Type,
         else
             @error "Error should not occur (buildOption = $buildOption)"
         end
+    else
+        # ndofTotal == 0
+        mbsCode = mbs_variables | Model(equations = :[$(mbs_equations...)])
     end
     
     # Store info in buildDict

--- a/src/Shapes/massProperties.jl
+++ b/src/Shapes/massProperties.jl
@@ -15,7 +15,7 @@ struct MassProperties{F <: Modia3D.VarFloatType} <: Modia3D.AbstractMassProperti
     #---------------- different constructors for MassProperties -----------------
     # Constructor 0: takes mass, centerOfMass and inertiaMatrix as input values
     function MassProperties{F}(mass::Number, centerOfMass::AbstractVector, inertiaMatrix::AbstractMatrix) where F <: Modia3D.VarFloatType
-        @assert(mass > 0.0)
+        @assert(mass >= 0.0)
         new(mass, centerOfMass, inertiaMatrix)
     end
 end

--- a/src/Shapes/palettes.jl
+++ b/src/Shapes/palettes.jl
@@ -14,7 +14,7 @@ Read the palettes for which a file name is given and store them as global palett
 If `log=true`, log the reading of the files.
 
 When Modia3D is used the first time, it reads the palettes automatically from
-`"Modia3D/palettes/*.sjon"`. The `loadPalettes` function overwrites this default setting.
+`"Modia3D/palettes/*.json"`. The `loadPalettes` function overwrites this default setting.
 
 # Examples
 

--- a/src/Shapes/solid.jl
+++ b/src/Shapes/solid.jl
@@ -88,7 +88,7 @@ struct Solid{F <: Modia3D.VarFloatType} <: Modia3D.AbstractObject3DFeature
         collisionSmoothingRadius=F(0.001),
         visualMaterial::Union{Shapes.VisualMaterial,AbstractString,Nothing} = Shapes.VisualMaterial(),
         visualMaterialConvexDecomposition::Union{Shapes.VisualMaterial,AbstractString,Nothing} = Shapes.VisualMaterial(),
-        contactSphereRadius::Union{Nothing, F} = nothing) where F <: Modia3D.VarFloatType
+        contactSphereRadius::Union{Nothing, Number} = nothing) where F <: Modia3D.VarFloatType
 
         if collision && isnothing(shape)
             error("For collision/gripping simulations, a shape must be defined.")
@@ -119,6 +119,7 @@ struct Solid{F <: Modia3D.VarFloatType} <: Modia3D.AbstractObject3DFeature
         end
 
         massProperties = createMassProperties(F, massProperties, shape, solidMaterial)
+        contactSphereRadius::Union{Nothing,F} = isnothing(contactSphereRadius) || F(contactSphereRadius) <= F(0) ? nothing : F(contactSphereRadius)
         (isFlat, contactSphereRadius) = setContactSphereRadius(shape, contactSphereRadius, F)
         new(shape, solidMaterial, massProperties, collision, contactMaterial, setCollisionSmoothingRadius(shape, F(collisionSmoothingRadius)), visualMaterial, isFlat, contactSphereRadius)
     end

--- a/src/Shapes/visual.jl
+++ b/src/Shapes/visual.jl
@@ -1,6 +1,7 @@
 convertStringToVisualMaterial(visualMaterial::Shapes.VisualMaterial) = visualMaterial
 
-convertStringToVisualMaterial(visualMaterial::AbstractString) = Shapes.visualMaterialPalette[visualMaterial]
+convertStringToVisualMaterial(visualMaterial::AbstractString) = visualMaterial == "" ? Shapes.VisualMaterial() : Shapes.visualMaterialPalette[visualMaterial]
+
 
 """
     Visual(;


### PR DESCRIPTION
- Model3D(..) with no degrees of freedom is now supported (previously, an error was triggered).

- Massless solid is now supported (previously, an error was triggered if Solid(..) had zero mass).  

- SolidMaterial, MassProperties, VisualMaterial in Solid(..) and VisualMaterial in Visual(..) improved to handle corner cases:
  - SolidMaterial=="" is treated as SolidMaterial = nothing
  - VisualMaterial=="" is treated as Shapes.VisualMaterial(), that is the default VisualMaterial.
  - massProperties==nothing && solidMaterial==nothing is treated as MassProperties(), that is as massless solid.

- Error message improved, if closed kinematic loop is detected. Especially, the names of all Object3Ds in the kinematic loop are printed.

- Error message improved, if no Scene is defined.  

- solid(..., contactSphereRadius::Union{Nothing,FloatType}=xxx) improved:
  - changed to contactSphereRadius::Union{Nothing,Number} (e.g. Int is also allowed).
  - contactSphereRadius <= 0 is the same as contactSphereRadius = nothing.

- Removed keyword "path" from the docu of Prismatic, Revolute, FreeMotion, since not to be set by the user (path is set when calling Model3D(..) to store the absolute path name in the joint).
 