### PR TITLE
Enable AnimationExport in case of no renderer available

### DIFF
--- a/src/AnimationExport/exportAnimation.jl
+++ b/src/AnimationExport/exportAnimation.jl
@@ -436,16 +436,16 @@ end
 
 
 function exportAnimation(scene)
-    animationFile = scene.options.animationFile
     allVisuElements = scene.allVisuElements
-    animation = scene.animation
-    if length(allVisuElements) > 0 && !isnothing(animationFile)
+    if scene.exportAnimation && length(allVisuElements) > 0
+        animationFile = scene.options.animationFile
         (head,ext) = splitext(animationFile)
         if ext != ".json"
             @warn("The path of an animationFile=$animationFile must end with .json.")
             return nothing
         end
         print("Export animation to $animationFile ... ")
+        animation = scene.animation
         elements = (; geometries=[], materials=[], shapes=[])
         metadata = (; generator = "Modia3D", type = "Object")
         name = scene.name
@@ -490,4 +490,13 @@ function exportAnimation(scene)
 
         println("done.")
     end
+end
+
+
+function Composition.isVisible(feature::Shapes.Solid{F}, exportAnimation::Bool) where F <: Modia3D.VarFloatType
+    return exportAnimation && !isnothing(feature.shape) && !isnothing(feature.visualMaterial)
+end
+
+function Composition.isVisible(feature::Shapes.Visual, exportAnimation::Bool)
+    return exportAnimation && !isnothing(feature.visualMaterial) && !isnothing(feature.shape)
 end

--- a/src/Composition/assignObjects.jl
+++ b/src/Composition/assignObjects.jl
@@ -35,8 +35,8 @@ end
 
 function assignObj(scene::Scene{F}, superObjType::SuperObjVisu{F}, obj::Object3D{F}, actPos::Int64)::Nothing where F <: Modia3D.VarFloatType
     renderer = Modia3D.renderer[1]
-    if ( isVisible(obj, renderer) || !isnothing(obj.visualizationFrame)  ) && !hasJoint(obj) && !canCollide(obj) && !hasForceElement(obj) && !hasChildJoint(obj) #&& !hasCutJoint(obj) && !featureHasMass(obj)
-        # if an Object3D is for visualization only it is stored in updateVisuElements
+    if ( isVisible(obj, renderer) || isVisible(obj, scene.exportAnimation) || !isnothing(obj.visualizationFrame)  ) && !hasJoint(obj) && !canCollide(obj) && !hasForceElement(obj) && !hasChildJoint(obj) #&& !hasCutJoint(obj) && !featureHasMass(obj)
+        # if an Object3D is for visualization/animation export only it is stored in updateVisuElements
         if !(obj in scene.updateVisuElements)
             push!(scene.updateVisuElements, obj)
         end
@@ -72,7 +72,7 @@ function fillVisuElements!(scene::Scene{F}, obj::Object3D{F}, world::Object3D{F}
                 push!(scene.updateVisuElements, obj)
             end
         end
-        if isVisible(obj, Modia3D.renderer[1])  # todo: should not affect animation export; move to initializeVisualization?
+        if isVisible(obj, Modia3D.renderer[1]) || isVisible(obj, scene.exportAnimation)  # visible in visualization or animation export
             push!(scene.allVisuElements, obj)
         end
     end

--- a/src/Composition/object3D.jl
+++ b/src/Composition/object3D.jl
@@ -640,9 +640,11 @@ featureHasMass(feature::Modia3D.AbstractScene) = false
 featureHasMass(feature::Shapes.Solid{F}) where F <: Modia3D.VarFloatType = !isnothing(feature.massProperties)
 
 isVisible(obj::Object3D{F}, renderer::Modia3D.AbstractRenderer) where F <: Modia3D.VarFloatType = isVisible(obj.feature, renderer)
+isVisible(obj::Object3D{F}, exportAnimation::Bool) where F <: Modia3D.VarFloatType = isVisible(obj.feature, exportAnimation)
 isVisible(feature::Modia3D.AbstractObject3DFeature, renderer::Modia3D.AbstractRenderer) = false
-
+isVisible(feature::Modia3D.AbstractObject3DFeature, exportAnimation::Bool) = false
 isVisible(feature::Modia3D.AbstractScene, renderer::Modia3D.AbstractRenderer) = false
+isVisible(feature::Modia3D.AbstractScene, exportAnimation::Bool) = false
 
 canCollide(feature::Modia3D.AbstractObject3DFeature) = false
 

--- a/src/renderer/DLR_Visualization/handler.jl
+++ b/src/renderer/DLR_Visualization/handler.jl
@@ -60,15 +60,9 @@ end
 
 
 function Composition.isVisible(feature::Shapes.Solid{F}, renderer::Modia3D.AbstractDLR_VisualizationRenderer) where F <: Modia3D.VarFloatType
-    return !isnothing(feature.visualMaterial) && !isnothing(feature.shape)
+    return !isnothing(feature.shape) && !isnothing(feature.visualMaterial)
 end
 
 function Composition.isVisible(feature::Shapes.Visual, renderer::Modia3D.AbstractDLR_VisualizationRenderer)
-    if isnothing(feature.shape)
-        return false
-    elseif typeof(feature.shape) == Shapes.TextShape
-        return typeof(renderer) != CommunityEdition
-    else
-        return !isnothing(feature.visualMaterial)
-    end
+    return !isnothing(feature.shape) && !isnothing(feature.visualMaterial)
 end

--- a/src/renderer/DLR_Visualization/visualize.jl
+++ b/src/renderer/DLR_Visualization/visualize.jl
@@ -123,7 +123,7 @@ function visualizeObject(obj::Composition.Object3D{F}, id::Ptr{Nothing}, simVis:
                              fileMesh.filename, Cint(fileMesh.smoothNormals), fileMesh.useMaterialColor, MVector{3,Cint}(obj.visualMaterial.color),
                              Cint(obj.visualMaterial.shadowMask), emptyShaderName)
 
-    elseif shapeKind == Modia3D.TextKind
+    elseif shapeKind == Modia3D.TextKind && simVis.isProfessionalEdition  # function setTextObject is not available in community edition
         textShape::Modia3D.Shapes.TextShape = obj.shape
         SimVis_setTextObject(simVis, id, Cint(textShape.axisAlignment), textShape.text, 0.0, Cint(0), r_abs, R_abs,
                              textShape.font.charSize, textShape.font.fontFileName, MVector{3,Cint}(textShape.font.color), textShape.font.transparency,


### PR DESCRIPTION
- Always consider Object3Ds for AnimationExport in Scene.allVisuElements and Scene.updateVisuElements
- This fixes https://github.com/ModiaSim/Modia3D.jl/issues/124