### PR TITLE
Fix FileMesh handling of AnimationExport

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -99,6 +99,7 @@ julia -JModia3D_sysimage.so  (otherwise)
 - Add Result Element SensorResult
 - Enable kinematic chain flipping for structure variable systems
 - Avoid function code generation for linear stiffness and damping in SpringDamperPtP and Bushing
+- Enable FileMesh support in AnimationExport for other mesh file formats than obj
 
 
 ### Version 0.12.2

--- a/src/AnimationExport/exportAnimation.jl
+++ b/src/AnimationExport/exportAnimation.jl
@@ -255,15 +255,12 @@ function exportObject(object, elements, obj::Modia3D.Composition.Object3D, fileM
     (head,ext) = splitext(filenameOld)
     if ext == ".json"
         filename = filenameOld
-    elseif ext == ".obj"
+    else
         filename = head * ".json"
         if !isfile(filename)
-            @warn("Please convert $filenameOld into a .json file.")
-            return nothing
+            @warn("Only FileMeshes in three.js json object scene format are supported by AnimationExport.\nPlease convert $filenameOld into a .json file and move it to the same folder.")
+            return (nothing, nothing)
         end
-    else
-        @warn("Please convert $filenameOld into a .json file.")
-        return nothing
     end
 
     io = open(filename, "r")


### PR DESCRIPTION
- Enable FileMesh support for other mesh file formats than obj.
- Improve error handling.